### PR TITLE
feat: add open modal shortcut key customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,62 @@ This issue should not occur in production environments, as data isn't frequently
 
 ## Customize modal behaviors
 
+###  Open with a shortcut :
+
+By default, this plugin includes a shortcut to open the modal. 
+If you want to disable the shortcut, You can do this using the  following approach 
+```php
+use CharrafiMed\GlobalSearchModal\GlobalSearchModalPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ...
+        ->plugins([
+            GlobalSearchModalPlugin::make()
+                ->openWithShortcut(condition:false)
+        ])
+}
+```
+
+You can also pass a Closure to the `openWithShortcut` method to customize the conditions 
+for opening the modal. The `Closure` should return a `boolean` value, 
+determining whether the modal should open based on your specified logic.
+
+```php
+use CharrafiMed\GlobalSearchModal\GlobalSearchModalPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ...
+        ->plugins([
+            GlobalSearchModalPlugin::make()
+                ->openWithShortcut(fn() => auth()->check() && auth()->id() === 1) // opens the modal only if the user is authenticated and has an ID of 1
+        ])
+}
+```
+
+### Define the shortcut key
+
+You can customize the shortcut key for opening the modal using the `shortcutKey` method. 
+By default, the shortcut is set to / (forward slash), and it can be changed 
+to any valid key value. The key is combined with either the Ctrl or Command 
+modifier, allowing you to open the modal with shortcuts like `Ctrl + /` or `Command + /`
+```php
+use CharrafiMed\GlobalSearchModal\GlobalSearchModalPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        ...
+        ->plugins([
+            GlobalSearchModalPlugin::make()
+                ->shortcutKey('k') // sets the shortcut key to 'k'
+        ])
+}
+```
+
 ###  Close by escaping : 
 by default this plugin comes with close-by escaping enabled, if  you want to  customize the close-by escaping behavior you can do it like so : 
 ```php
@@ -87,6 +143,7 @@ public function panel(Panel $panel): Panel
                 ->closeByEscaping(enabled: false)
         ])
 }
+
 ```
 ###  Close by clicking away :
 by default this plugin comes with a modal that can close by clicking away enabled, if  you want to  customize the close by clicky away behavior you can do it like so : 
@@ -104,7 +161,7 @@ public function panel(Panel $panel): Panel
 }
 ```
 ###  Close button 
-By default, the plugin does not include a close button. To add a close button:
+By default, the close button is enabled, if you want to disable it, you can do it like so :
 
 ```php
 use CharrafiMed\GlobalSearchModal\GlobalSearchModalPlugin;
@@ -115,7 +172,7 @@ public function panel(Panel $panel): Panel
         ...
         ->plugins([
             GlobalSearchModalPlugin::make()
-                ->closeButton(enabled: true)
+                ->closeButton(enabled: false)
         ])
 }
 ```

--- a/resources/views/components/modal/index.blade.php
+++ b/resources/views/components/modal/index.blade.php
@@ -19,48 +19,56 @@
     $left = $position?->getLeft() ?? '0';
     $right = $position?->getRight() ?? '0';
     $bottom = $position?->getBottom() ?? '0';
+		$shortcutKey = $this->getConfigs()->getShortcutKey();
+		$isOpenWithShortcutEnabled = $this->getConfigs()->isOpenWithShortcutEnabled();
 @endphp
 
-<div 
-    @class(['flex justify-center']) 
+<div
+    @class(['flex justify-center'])
     >
     {{-- <script src="https://cdn.tailwindcss.com"></script> --}}
-    <div 
+    <div
         @class([
             'fixed inset-0 z-40 overflow-y-hidden',
             'sm:pt-0'=> !$isSlideOver
-        ]) 
-        role="dialog" 
-        aria-modal="true" 
+        ])
+        role="dialog"
+        aria-modal="true"
         style="display: none"
         x-show="$store.globalSearchModalStore.isOpen"
-        
-        @if ($isClosedByEscaping)
-             x-on:keydown.escape.window="$store.globalSearchModalStore.hideModal()" 
+
+        @if($isOpenWithShortcutEnabled)
+            x-on:keydown.window="
+                if ((event.metaKey || event.ctrlKey) && event.key === '{{ $shortcutKey }}') { $store.globalSearchModalStore.showModal() }
+            "
         @endif
-        x-id="['modal-title']" 
+
+        @if ($isClosedByEscaping)
+             x-on:keydown.escape.window="$store.globalSearchModalStore.hideModal()"
+        @endif
+        x-id="['modal-title']"
         x-bind:aria-labelledby="$id('modal-title')">
 
         <!-- Overlay -->
-        <div 
+        <div
         @class([
           'global-search-modal-overlay fixed inset-0 bg-black bg-opacity-60 backdrop-blur-lg'
         ])
         x-show="$store.globalSearchModalStore.isOpen"
         x-transition.opacity
-        
+
         >
         </div>
 
         <!-- Panel -->
         <div class="global-search-modal-panel">
-            <div 
-                class="relative flex min-h-screen items-center justify-center p-4" 
+            <div
+                class="relative flex min-h-screen items-center justify-center p-4"
                 x-show="$store.globalSearchModalStore.isOpen"
-                x-transition 
-                
-                @if ($isClosedByClickingAway) 
-                    x-on:click="$store.globalSearchModalStore.hideModal()" 
+                x-transition
+
+                @if ($isClosedByClickingAway)
+                    x-on:click="$store.globalSearchModalStore.hideModal()"
                 @endif
                 >
                 <div

--- a/src/Concerns/CanCustomizeModalBehaviors.php
+++ b/src/Concerns/CanCustomizeModalBehaviors.php
@@ -18,6 +18,10 @@ trait CanCustomizeModalBehaviors
 
     public  bool $isSlideOver = false;
     
+    public bool|Closure $openWithShortcut = true;
+    
+    public string $shortcutKey = '/';
+    
     protected ?Position $position = null;
 
     public function position(Closure $callback): self
@@ -80,5 +84,29 @@ trait CanCustomizeModalBehaviors
     public function isSlideOver(): bool
     {
         return $this->isSlideOver;
+    }
+    
+    public  function openWithShortcut(bool|Closure $condition = true): self
+    {
+        $this->openWithShortcut = $condition;
+        
+        return $this;
+    }
+    
+    public  function isOpenWithShortcutEnabled(): bool
+    {
+        return $this->evaluate($this->openWithShortcut);
+    }
+    
+    public function shortcutKey(string $key): self
+    {
+        $this->shortcutKey = $key;
+        return $this;
+    }
+    
+    public function getShortcutKey(): string
+    {
+        
+        return $this->shortcutKey;
     }
 }

--- a/src/GlobalSearchModalPlugin.php
+++ b/src/GlobalSearchModalPlugin.php
@@ -2,8 +2,10 @@
 
 namespace CharrafiMed\GlobalSearchModal;
 
+use CharrafiMed\GlobalSearchModal\Concerns\CanBeOpenedWithShortcut;
 use Filament\Panel;
 use Filament\Contracts\Plugin;
+use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Support\Facades\Blade;
 use CharrafiMed\GlobalSearchModal\Concerns\CanBeSwappableOnMobile;
@@ -29,9 +31,8 @@ class GlobalSearchModalPlugin implements Plugin
     use CanHighlightQueryMatches;
     use HasAccessibilityElements;
     use HasPlaceHolder;
-
-
- 
+    use EvaluatesClosures;
+    
     public static function make()
     {
         return app(static::class);


### PR DESCRIPTION
Implemented options to enable opening the modal with a keyboard shortcut and customize the shortcut key. Updated documentation and refactored the modal component to support these new features.