### PR TITLE
Fixed 'getResults' early return when search is empty

### DIFF
--- a/src/Livewire/GlobalSearchModal.php
+++ b/src/Livewire/GlobalSearchModal.php
@@ -33,17 +33,18 @@ class GlobalSearchModal extends Component
         if (!$this->hasTenantOrIsAuthenticated()) {
             return null;
         }
+
         // Early return if the search is empty
         $search = trim($this->search);
-
+        if (empty($search)) {
+            return null;
+        }
 
         $results = Filament::getGlobalSearchProvider()->getResults($search);
-
 
         if (!$results || !$this->getConfigs()->isMustHighlightQueryMatches()) {
             return $results;
         }
-        
 
         $classes = $this->getConfigs()->getHighlightQueryClasses() ?? 'text-primary-500 font-semibold hover:underline';
         $styles = $this->getConfigs()->getHighlightQueryStyles() ?? '';

--- a/src/Livewire/GlobalSearchModal.php
+++ b/src/Livewire/GlobalSearchModal.php
@@ -37,7 +37,7 @@ class GlobalSearchModal extends Component
         // Early return if the search is empty
         $search = trim($this->search);
         if (empty($search)) {
-            return null;
+            return GlobalSearchResults::make();
         }
 
         $results = Filament::getGlobalSearchProvider()->getResults($search);


### PR DESCRIPTION
This PR adds an early return in the `getResults` method to stop the global search from querying all related resources when the search input is empty or whitespace. This improves performance by avoiding redundant operations and ensures that no unnecessary calls are made to `getGlobalSearchProvider`.

What has been changed:

	•	Added a check to trim the search input.
	•	If the search input is empty after trimming, the method immediately returns null.
	•	Prevents unnecessary resource querying and improves efficiency.

Why is this needed:

	•	Previously, the global search would query all related resources even when no meaningful search input was provided, leading to wasted queries and slower performance.
	•	This fix ensures resources are queried only when there’s a valid search input.

Same fix as provided by https://github.com/vittosheva on https://github.com/CharrafiMed/global-search-modal/issues/74