### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/Livewire/GlobalSearchModal.php
+++ b/src/Livewire/GlobalSearchModal.php
@@ -11,6 +11,7 @@ use Filament\GlobalSearch\GlobalSearchResult;
 use Filament\GlobalSearch\GlobalSearchResults;
 use CharrafiMed\GlobalSearchModal\Utils\Highlighter;
 
+#[AllowDynamicProperties]
 class GlobalSearchModal extends Component
 {
     public ?string $search = '';


### PR DESCRIPTION
After deploying your package, I keep getting hundreds of deprecation warnings in Sentry

```bash
Creation of dynamic property Filament\GlobalSearch\GlobalSearchResult::$highlightedTitle is deprecated
```

It turns out that Filament's GlobalSearchResult class didn't have this property, you dynamically added it yourself.

So I added #[AllowDynamicProperties] to the top of the class to ask PHP to ignore this deprecation

For more information, see:

https://php.watch/versions/8.2/dynamic-properties-deprecated

If you have a way to not even use dynamic properties, that is even better