### PR TITLE
fix #70 - url not saved in favorites

### DIFF
--- a/resources/views/components/search/summary/summary-wrapper.blade.php
+++ b/resources/views/components/search/summary/summary-wrapper.blade.php
@@ -25,7 +25,7 @@ x-on:focus-first-element.window="($el.querySelector('.fi-global-search-result-li
     
                             <x-global-search-modal::search.action-button
                                 title="favorite this item"
-                                clickFunction="addToFavorites(result.item, result.group)"
+                                clickFunction="addToFavorites(result.item, result.group, result.url)"
                                 icon="favorite"
                                 />
     


### PR DESCRIPTION
When adding an item to favorites, it only copies over the item and group keys, not the url key.

This fix adds the url as well.