### PR TITLE
fix(animate-directive): Handle missing duration value in x-animate modifier

### DIFF
--- a/dist/modalStore.js
+++ b/dist/modalStore.js
@@ -496,17 +496,17 @@ var src_default = (Alpine2) => {
       const durationIndex = modifiers.indexOf("duration");
       const durationValue = modifiers[durationIndex + 1];
       const durationRegex = /^(\d+)(ms|s)?$/;
-      if (durationRegex.test(durationValue)) {
-        const match = durationRegex.exec(durationValue);
-        const durationNumber = parseInt(match[1], 10);
-        const durationUnit = match[2] || "ms";
-        configs.duration = durationUnit === "s" ? durationNumber * 1e3 : durationNumber;
+
+      // Check if a value is provided after the "duration" modifier
+      if (durationValue && durationRegex.test(durationValue)) {
+          const match = durationValue.match(durationRegex);
+          const durationNumber = parseInt(match[1], 10);
+          const durationUnit = match[2] || "ms";
+          configs.duration = durationUnit === "s" ? durationNumber * 1e3 : durationNumber;
       } else {
-        console.warn("Invalid duration format. Use digits followed by 'ms' or 's'.");
+          console.warn('The "duration" modifier requires a value (e.g., "500ms" or "2s").');
       }
-    } else {
-      console.warn('The "duration" modifier was specified without a value.');
-    }
+      }
     if (modifiers.includes("easing")) {
       const easingValue = modifiers[modifiers.indexOf("easing") + 1];
       easingValue ? configs.easing = easingValue : console.warn('The "easing" modifier was specified without a value.');


### PR DESCRIPTION
This PR fixes an issue where the duration modifier in the x-animate directive was not properly handled when no value was provided. Previously, the code would log a warning but not handle the case where the modifier was present without a value. 
**This fix ensures that:**
    1. The duration modifier is validated correctly.
    2. No uncessary duration modifier warning is logged.
    3. The directive continues to function as expected for valid inputs.
**Changes:**
    1. Updated the logic for handling the duration modifier in the x-animate directive.
    2. Added validation to check for a valid duration value after the duration modifier.

![image](https://github.com/user-attachments/assets/7a740bb0-53ef-4169-99e4-0c5c608e4a1d)

…difier