### PR TITLE
Fix: Prevent wrong URL navigation when clicking recent search items

### DIFF
--- a/resources/views/components/search/summary/item.blade.php
+++ b/resources/views/components/search/summary/item.blade.php
@@ -11,8 +11,13 @@
         x-bind:href="result.url"
         
         x-on:click.stop="
+        let targetUrl = result.url;
+        let targetItem = result.item;
+        let targetGroup = result.group;
         $store.globalSearchModalStore.hideModal();
-        addToSearchHistory(result.item,result.group,result.url)
+        window.addEventListener('beforeunload', () => {
+            addToSearchHistory(targetItem, targetGroup, targetUrl);
+        }, { once: true });
         "
         
         x-on:keydown.enter.stop="$store.globalSearchModalStore.hideModal()"


### PR DESCRIPTION
Previously clicking a recent search result would navigate to the item on top of the clicked item. This happened because it first reordered the array when clicking, and then navigated to whichever item was pushed into the array index that was clicked. 

This update fixes that behavior.