### PR TITLE
Remove HTML string sanitization for SearchResult title id Title already is HMLString

### DIFF
--- a/resources/views/components/search/result-item.blade.php
+++ b/resources/views/components/search/result-item.blade.php
@@ -48,9 +48,13 @@ $isAssoc = \Illuminate\Support\Arr::isAssoc($result->details);
                 'text-sm text-start font-medium text-gray-950 dark:text-white',
             ])
         >
-            <span>
-                {{ str($title)->sanitizeHtml()->toHtmlString() }}
-            </span>
+            @if($title instanceof \Illuminate\Contracts\Support\Htmlable)
+                {{ $title }}
+            @else
+                <span>
+                 {{ str($title)->sanitizeHtml()->toHtmlString() }}
+                </span>
+            @endif
         </h4>
 
         @if ($result->details)


### PR DESCRIPTION
If you would add a SVG into your getGlobalSearchResultTitle(). SVG would be filterd out by the duplicate sanitization. 
This PR Checks if the $tile already is a HTMLString and does not sanitize it again so the HTML keeps Completely intact.

Example: 
```php
public static function getGlobalSearchResultTitle(?Model $record): Htmlable
{
    return new HtmlString("<div><svg>....</svg>{$record->name}</div>");
}
```